### PR TITLE
chore: move controller image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-# base image
-FROM debian:bullseye
+ARG UNIFI_CONTROLLER_VERSION=9.4.19
+
+FROM debian:bookworm-slim AS downloader
+ARG UNIFI_CONTROLLER_VERSION
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Build arguments
-ARG UNIFI_CONTROLLER_VERSION=9.4.19
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail --silent --show-error --location "https://dl.ui.com/unifi/${UNIFI_CONTROLLER_VERSION}/unifi_sysvinit_all.deb" \
+      -o "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb"
+
+FROM debian:bookworm-slim
+ARG UNIFI_CONTROLLER_VERSION
 ARG BUILD_DATE
 ARG VCS_REF
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# OCI-compliant image labels
+ENV DEBIAN_FRONTEND=noninteractive
+
 LABEL \
     org.opencontainers.image.title="Unifi Controller" \
     org.opencontainers.image.description="Unifi Controller without a local MongoDB instance" \
@@ -19,36 +32,32 @@ LABEL \
     org.opencontainers.image.vendor="Sea the Good, LLC" \
     org.opencontainers.image.licenses="MIT"
 
-# build environment variables
 ENV \
-	BIND_PRIV=false \
-	DEBIAN_FRONTEND=noninteractive \
-	DEBUG=false \
-	JVM_EXTRA_OPTS= \
-	JVM_INIT_HEAP_SIZE= \
-	JVM_MAX_HEAP_SIZE=1024M \
-	PGID=999 \
-	PUID=999 \
-	RUN_CHOWN=true \
-	RUNAS_UID0=false
+    BIND_PRIV=false \
+    DEBUG=false \
+    JVM_EXTRA_OPTS= \
+    JVM_INIT_HEAP_SIZE= \
+    JVM_MAX_HEAP_SIZE=1024M \
+    PGID=999 \
+    PUID=999 \
+    RUN_CHOWN=true \
+    RUNAS_UID0=false
 
-# copy in logical defaults for unifi
 COPY entrypoint.sh entrypoint-functions.sh healthcheck.sh /usr/local/bin/
 COPY system.properties.default /usr/lib/unifi/
 
-# setup security context for the unifi user
 RUN set -x \
-	&& groupadd -r unifi -g $PGID \
-	&& useradd --no-log-init -r -u $PUID -g $PGID unifi
+    && groupadd -r unifi -g $PGID \
+    && useradd --no-log-init -r -u $PUID -g $PGID unifi
 
-# setup directory structure for unifi
 RUN mkdir -p /usr/lib/unifi/data /usr/lib/unifi/logs /usr/lib/unifi/run /usr/lib/unifi/cert \
-    && chown -R unifi:unifi /usr/lib/unifi \
-    && ls -ld /usr/lib/unifi/*
+    && chown -R unifi:unifi /usr/lib/unifi
 
-# install unifi dependencies
+COPY --from=downloader "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb" /tmp/unifi.deb
+
 RUN set -x \
-    && fetchDeps=' \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         binutils \
         ca-certificates \
         curl \
@@ -62,24 +71,15 @@ RUN set -x \
         procps \
         publicsuffix \
         wget \
-    ' \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $fetchDeps \
-    && apt-get autoremove --purge \
-    && apt-get clean autoclean 
+    && dpkg-deb --info /tmp/unifi.deb > /dev/null \
+    && test -n "$(dpkg-deb --field /tmp/unifi.deb Package)" \
+    && dpkg --force-all -i /tmp/unifi.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*
 
-# download and install the unifi controller
 WORKDIR /usr/lib/unifi
-RUN echo "Fetching: https://dl.ui.com/unifi/${UNIFI_CONTROLLER_VERSION}/unifi_sysvinit_all.deb"
-RUN curl --fail --silent --show-error --location "https://dl.ui.com/unifi/${UNIFI_CONTROLLER_VERSION}/unifi_sysvinit_all.deb" \
-      -o "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb" \
-  && dpkg-deb --info "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb" > /dev/null \
-  && test -n "$(dpkg-deb --field "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb" Package)" \
-  && dpkg --force-all -i "/tmp/unifi-${UNIFI_CONTROLLER_VERSION}.deb" \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*
 
-# setup port and volume options
-EXPOSE 3478/udp 5514/udp 8080/tcp 8443/tcp 8880/tcp 8843/tcp 6789/tcp 27117/tcp 10001/udp 1900/udp 123/udp 
+EXPOSE 3478/udp 5514/udp 8080/tcp 8443/tcp 8880/tcp 8843/tcp 6789/tcp 27117/tcp 10001/udp 1900/udp 123/udp
 
 VOLUME ["/usr/lib/unifi/cert", "/usr/lib/unifi/data", "/usr/lib/unifi/logs"]
 


### PR DESCRIPTION
**Summary**

- Switch the UniFi controller image from Debian Bullseye to Debian Bookworm for a fresher security baseline.
- Download the UniFi .deb in a Bookworm “downloader” stage, then install it in a separate Bookworm runtime stage to keep the final image lean.
- Install the runtime packages explicitly and skip the apt-get autoremove step that was tripping over UniFi’s optional MongoDB dependency.
- Ensure the existing entrypoint scripts, data directories, and volume mounts keep working unchanged.

**Testing**

1. ./build.sh --version 9.4.19 --clean (load-mode build on ARM64 host)
2. docker compose up -d
3. Tail combo logs + smoke tests
- docker compose logs -f unifi-controller
- nc -zu localhost 10001
- curl -k https://localhost:8443/ → UniFi setup UI loads
- docker compose exec unifi-controller ps aux | grep java (controller process running)

Everything came up clean; UniFi connects to Mongo, the UI serves from 8443, and the Bookworm base contains no extra WARNs beyond the usual self-signed certificate notice.